### PR TITLE
Ai agent mcp endpoint

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -22,6 +22,36 @@ The API exposes the following endpoint categories:
   - Get rates by issuer
   - Get historical rates time series
 
+- **MCP (Model Context Protocol)**: `/api/v1/mcp`
+  - JSON-RPC endpoint exposing MCP tools for the rates API
+  - Methods: `initialize`, `tools/list`, `tools/call`, `ping`
+
+Example MCP request (list tools):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list"
+}
+```
+
+Example MCP request (call tool):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "list_mortgage_rates",
+    "arguments": {
+      "termInMonths": "12"
+    }
+  }
+}
+```
+
 All endpoints support CORS and return JSON responses with a 5-second cache control.
 
 ## API Documentation

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { Institution, Issuer, Plan, Product, Rate } from "./models";
 import {
   carLoanRatesRoutes,
   creditCardRatesRoutes,
+  mcpRoutes,
   mortgageRatesRoutes,
   personalLoanRatesRoutes,
 } from "./routes";
@@ -66,6 +67,7 @@ app.route("/api/v1/mortgage-rates", mortgageRatesRoutes);
 app.route("/api/v1/personal-loan-rates", personalLoanRatesRoutes);
 app.route("/api/v1/car-loan-rates", carLoanRatesRoutes);
 app.route("/api/v1/credit-card-rates", creditCardRatesRoutes);
+app.route("/api/v1/mcp", mcpRoutes);
 
 // Models
 app.openAPIRegistry.register("Institution", Institution);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,4 +1,5 @@
 export { routes as carLoanRatesRoutes } from "./car-loan-rates";
 export { routes as creditCardRatesRoutes } from "./credit-card-rates";
+export { routes as mcpRoutes } from "./mcp";
 export { routes as mortgageRatesRoutes } from "./mortgage-rates";
 export { routes as personalLoanRatesRoutes } from "./personal-loan-rates";

--- a/src/routes/mcp/index.ts
+++ b/src/routes/mcp/index.ts
@@ -1,0 +1,651 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { Context } from "hono";
+import { Environment } from "../../lib/environment";
+
+type JsonRpcId = string | number | null;
+
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: JsonRpcId;
+  method?: string;
+  params?: unknown;
+};
+
+type JsonRpcError = {
+  code: number;
+  message: string;
+  data?: unknown;
+};
+
+type JsonRpcResponse = {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  result?: unknown;
+  error?: JsonRpcError;
+};
+
+type McpTool = {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+    additionalProperties: boolean;
+  };
+};
+
+class JsonRpcErrorResponse extends Error {
+  code: number;
+  data?: unknown;
+
+  constructor(code: number, message: string, data?: unknown) {
+    super(message);
+    this.code = code;
+    this.data = data;
+  }
+}
+
+class McpToolError extends Error {
+  status: number;
+  body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+const MCP_PROTOCOL_VERSION = "2024-11-05";
+
+const MCP_SERVER_INFO = {
+  name: "ratesapi-mcp",
+  version: "1.0.0",
+};
+
+const MCP_TOOLS: McpTool[] = [
+  {
+    name: "list_mortgage_rates",
+    description: "List latest mortgage rates for all institutions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        termInMonths: {
+          type: "string",
+          description: "Optional mortgage term in months to filter by.",
+          examples: ["6", "12", "24", "36"],
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_mortgage_rates_by_institution",
+    description: "Get latest mortgage rates for a specific institution.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        institutionId: {
+          type: "string",
+          description: "Institution ID to filter by.",
+          examples: ["institution:anz"],
+        },
+        termInMonths: {
+          type: "string",
+          description: "Optional mortgage term in months to filter by.",
+          examples: ["6", "12", "24", "36"],
+        },
+      },
+      required: ["institutionId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_mortgage_rates_time_series",
+    description: "Get mortgage rates time series for a date or range.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        date: {
+          type: "string",
+          description: "Date in YYYY-MM-DD format for historical data.",
+          examples: ["2025-03-01"],
+        },
+        startDate: {
+          type: "string",
+          description: "Start date in YYYY-MM-DD format for time series.",
+          examples: ["2025-01-01"],
+        },
+        endDate: {
+          type: "string",
+          description: "End date in YYYY-MM-DD format for time series.",
+          examples: ["2025-03-01"],
+        },
+        institutionId: {
+          type: "string",
+          description: "Optional institution ID to filter time series data.",
+          examples: ["institution:anz"],
+        },
+        termInMonths: {
+          type: "string",
+          description: "Optional mortgage term in months to filter by.",
+          examples: ["6", "12", "24", "36"],
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_personal_loan_rates",
+    description: "List latest personal loan rates for all institutions.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_personal_loan_rates_by_institution",
+    description: "Get latest personal loan rates for a specific institution.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        institutionId: {
+          type: "string",
+          description: "Institution ID to filter by.",
+          examples: ["institution:anz"],
+        },
+      },
+      required: ["institutionId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_personal_loan_rates_time_series",
+    description: "Get personal loan rates time series for a date or range.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        date: {
+          type: "string",
+          description: "Date in YYYY-MM-DD format for historical data.",
+          examples: ["2025-03-01"],
+        },
+        startDate: {
+          type: "string",
+          description: "Start date in YYYY-MM-DD format for time series.",
+          examples: ["2025-01-01"],
+        },
+        endDate: {
+          type: "string",
+          description: "End date in YYYY-MM-DD format for time series.",
+          examples: ["2025-03-01"],
+        },
+        institutionId: {
+          type: "string",
+          description: "Optional institution ID to filter time series data.",
+          examples: ["institution:anz"],
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_car_loan_rates",
+    description: "List latest car loan rates for all institutions.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_car_loan_rates_by_institution",
+    description: "Get latest car loan rates for a specific institution.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        institutionId: {
+          type: "string",
+          description: "Institution ID to filter by.",
+          examples: ["institution:anz"],
+        },
+      },
+      required: ["institutionId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_car_loan_rates_time_series",
+    description: "Get car loan rates time series for a date or range.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        date: {
+          type: "string",
+          description: "Date in YYYY-MM-DD format for historical data.",
+          examples: ["2025-03-01"],
+        },
+        startDate: {
+          type: "string",
+          description: "Start date in YYYY-MM-DD format for time series.",
+          examples: ["2025-01-01"],
+        },
+        endDate: {
+          type: "string",
+          description: "End date in YYYY-MM-DD format for time series.",
+          examples: ["2025-03-01"],
+        },
+        institutionId: {
+          type: "string",
+          description: "Optional institution ID to filter time series data.",
+          examples: ["institution:anz"],
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_credit_card_rates",
+    description: "List latest credit card rates for all issuers.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_credit_card_rates_by_issuer",
+    description: "Get latest credit card rates for a specific issuer.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        issuerId: {
+          type: "string",
+          description: "Issuer ID to filter by.",
+          examples: ["issuer:anz"],
+        },
+      },
+      required: ["issuerId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_credit_card_rates_time_series",
+    description: "Get credit card rates time series for a date or range.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        date: {
+          type: "string",
+          description: "Date in YYYY-MM-DD format for historical data.",
+          examples: ["2025-03-01"],
+        },
+        startDate: {
+          type: "string",
+          description: "Start date in YYYY-MM-DD format for time series.",
+          examples: ["2025-01-01"],
+        },
+        endDate: {
+          type: "string",
+          description: "End date in YYYY-MM-DD format for time series.",
+          examples: ["2025-03-01"],
+        },
+        issuerId: {
+          type: "string",
+          description: "Optional issuer ID to filter time series data.",
+          examples: ["issuer:anz"],
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+];
+
+const routes = new OpenAPIHono<{ Bindings: Environment }>();
+
+routes.post("/", async (c) => {
+  let body: JsonRpcRequest;
+
+  try {
+    body = await c.req.json();
+  } catch (error) {
+    const response: JsonRpcResponse = {
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32700,
+        message: "Parse error",
+        data: error instanceof Error ? error.message : undefined,
+      },
+    };
+
+    return c.json(response, 400);
+  }
+
+  try {
+    const { id, hasId, method, params } = parseJsonRpcRequest(body);
+
+    const result = await handleMethod(method, params, c);
+
+    if (!hasId) {
+      return c.body(null, 204);
+    }
+
+    const response: JsonRpcResponse = {
+      jsonrpc: "2.0",
+      id,
+      result,
+    };
+
+    return c.json(response);
+  } catch (error) {
+    const { id, hasId } = parseRequestId(body);
+
+    if (!hasId) {
+      return c.body(null, 204);
+    }
+
+    const response: JsonRpcResponse = {
+      jsonrpc: "2.0",
+      id,
+      error: toJsonRpcError(error),
+    };
+
+    return c.json(response);
+  }
+});
+
+function parseJsonRpcRequest(body: JsonRpcRequest) {
+  if (!isRecord(body)) {
+    throw new JsonRpcErrorResponse(-32600, "Invalid Request");
+  }
+
+  if (body.jsonrpc !== "2.0") {
+    throw new JsonRpcErrorResponse(-32600, "Invalid Request");
+  }
+
+  if (typeof body.method !== "string" || body.method.length === 0) {
+    throw new JsonRpcErrorResponse(-32600, "Invalid Request");
+  }
+
+  const { id, hasId } = parseRequestId(body);
+
+  return {
+    id,
+    hasId,
+    method: body.method,
+    params: body.params,
+  };
+}
+
+function parseRequestId(body: JsonRpcRequest) {
+  const hasId = Object.prototype.hasOwnProperty.call(body, "id");
+  const id = hasId ? body.id ?? null : null;
+
+  if (hasId && id !== null && typeof id !== "string" && typeof id !== "number") {
+    throw new JsonRpcErrorResponse(-32600, "Invalid Request");
+  }
+
+  return { id, hasId };
+}
+
+function toJsonRpcError(error: unknown): JsonRpcError {
+  if (error instanceof JsonRpcErrorResponse) {
+    return {
+      code: error.code,
+      message: error.message,
+      data: error.data,
+    };
+  }
+
+  return {
+    code: -32603,
+    message: "Internal error",
+    data: error instanceof Error ? error.message : undefined,
+  };
+}
+
+async function handleMethod(
+  method: string,
+  params: unknown,
+  c: Context<{ Bindings: Environment }>
+) {
+  switch (method) {
+    case "initialize":
+      return {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        serverInfo: MCP_SERVER_INFO,
+        capabilities: {
+          tools: {
+            listChanged: false,
+          },
+        },
+      };
+    case "ping":
+      return {};
+    case "tools/list":
+      return {
+        tools: MCP_TOOLS,
+      };
+    case "tools/call":
+      return handleToolCall(params, c);
+    default:
+      throw new JsonRpcErrorResponse(-32601, `Method not found: ${method}`);
+  }
+}
+
+async function handleToolCall(
+  params: unknown,
+  c: Context<{ Bindings: Environment }>
+) {
+  if (!isRecord(params)) {
+    throw new JsonRpcErrorResponse(-32602, "Invalid params");
+  }
+
+  const name = params.name;
+  const args = params.arguments;
+
+  if (typeof name !== "string" || name.length === 0) {
+    throw new JsonRpcErrorResponse(-32602, "Invalid params: missing tool name");
+  }
+
+  if (args !== undefined && !isRecord(args)) {
+    throw new JsonRpcErrorResponse(-32602, "Invalid params: arguments must be an object");
+  }
+
+  try {
+    const result = await callTool(name, (args ?? {}) as Record<string, unknown>, c);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    if (error instanceof McpToolError) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                message: error.message,
+                status: error.status,
+                body: error.body,
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+
+    throw error;
+  }
+}
+
+async function callTool(
+  name: string,
+  args: Record<string, unknown>,
+  c: Context<{ Bindings: Environment }>
+) {
+  switch (name) {
+    case "list_mortgage_rates":
+      return fetchApi(c, "/api/v1/mortgage-rates", {
+        termInMonths: toOptionalString(args.termInMonths),
+      });
+    case "get_mortgage_rates_by_institution":
+      return fetchApi(
+        c,
+        `/api/v1/mortgage-rates/${encodeURIComponent(
+          toRequiredString(args.institutionId, "institutionId")
+        )}`,
+        {
+          termInMonths: toOptionalString(args.termInMonths),
+        }
+      );
+    case "get_mortgage_rates_time_series":
+      return fetchApi(c, "/api/v1/mortgage-rates/time-series", {
+        date: toOptionalString(args.date),
+        startDate: toOptionalString(args.startDate),
+        endDate: toOptionalString(args.endDate),
+        institutionId: toOptionalString(args.institutionId),
+        termInMonths: toOptionalString(args.termInMonths),
+      });
+    case "list_personal_loan_rates":
+      return fetchApi(c, "/api/v1/personal-loan-rates");
+    case "get_personal_loan_rates_by_institution":
+      return fetchApi(
+        c,
+        `/api/v1/personal-loan-rates/${encodeURIComponent(
+          toRequiredString(args.institutionId, "institutionId")
+        )}`
+      );
+    case "get_personal_loan_rates_time_series":
+      return fetchApi(c, "/api/v1/personal-loan-rates/time-series", {
+        date: toOptionalString(args.date),
+        startDate: toOptionalString(args.startDate),
+        endDate: toOptionalString(args.endDate),
+        institutionId: toOptionalString(args.institutionId),
+      });
+    case "list_car_loan_rates":
+      return fetchApi(c, "/api/v1/car-loan-rates");
+    case "get_car_loan_rates_by_institution":
+      return fetchApi(
+        c,
+        `/api/v1/car-loan-rates/${encodeURIComponent(
+          toRequiredString(args.institutionId, "institutionId")
+        )}`
+      );
+    case "get_car_loan_rates_time_series":
+      return fetchApi(c, "/api/v1/car-loan-rates/time-series", {
+        date: toOptionalString(args.date),
+        startDate: toOptionalString(args.startDate),
+        endDate: toOptionalString(args.endDate),
+        institutionId: toOptionalString(args.institutionId),
+      });
+    case "list_credit_card_rates":
+      return fetchApi(c, "/api/v1/credit-card-rates");
+    case "get_credit_card_rates_by_issuer":
+      return fetchApi(
+        c,
+        `/api/v1/credit-card-rates/${encodeURIComponent(
+          toRequiredString(args.issuerId, "issuerId")
+        )}`
+      );
+    case "get_credit_card_rates_time_series":
+      return fetchApi(c, "/api/v1/credit-card-rates/time-series", {
+        date: toOptionalString(args.date),
+        startDate: toOptionalString(args.startDate),
+        endDate: toOptionalString(args.endDate),
+        issuerId: toOptionalString(args.issuerId),
+      });
+    default:
+      throw new JsonRpcErrorResponse(-32601, `Tool not found: ${name}`);
+  }
+}
+
+async function fetchApi(
+  c: Context<{ Bindings: Environment }>,
+  pathname: string,
+  query?: Record<string, string | undefined>
+) {
+  const url = new URL(c.req.url);
+  url.pathname = pathname;
+  url.search = "";
+
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, value);
+      }
+    }
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  const body = await readJsonOrText(response);
+
+  if (!response.ok) {
+    throw new McpToolError(
+      `API request failed with status ${response.status}`,
+      response.status,
+      body
+    );
+  }
+
+  return body;
+}
+
+async function readJsonOrText(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value.toString();
+  }
+
+  return undefined;
+}
+
+function toRequiredString(value: unknown, name: string): string {
+  const normalized = toOptionalString(value);
+
+  if (!normalized) {
+    throw new JsonRpcErrorResponse(-32602, `Invalid params: ${name} is required`);
+  }
+
+  return normalized;
+}
+
+export { routes };


### PR DESCRIPTION
Add an MCP endpoint to enable AI agents to interact with the API via a standardized protocol.

The MCP endpoint provides a JSON-RPC interface at `/api/v1/mcp` with methods like `initialize`, `tools/list`, `tools/call`, and `ping`. It exposes existing rates API functionality as callable tools, allowing AI agents to discover and execute API operations programmatically. This includes listing and retrieving mortgage, personal loan, car loan, and credit card rates, as well as their historical time series data. Documentation for usage and examples has been added to `docs/api-endpoints.md`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6475c5f-d6ee-4e67-81b2-fea196db0fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6475c5f-d6ee-4e67-81b2-fea196db0fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new externally accessible JSON-RPC surface area that proxies to existing API endpoints; main risk is request/response handling and potential amplification/load from tool calls, but it doesn’t modify core rate calculation/storage logic.
> 
> **Overview**
> Adds a new `POST /api/v1/mcp` endpoint implementing the Model Context Protocol over JSON-RPC, including `initialize`, `ping`, `tools/list`, and `tools/call`.
> 
> `tools/call` exposes existing mortgage/personal loan/car loan/credit card rate reads (including time-series and issuer/institution filters) as named MCP tools, internally proxying requests to the corresponding REST endpoints and returning structured JSON-RPC errors.
> 
> Updates routing (`src/index.ts`, `src/routes/index.ts`) and documents the new MCP endpoint with example requests in `docs/api-endpoints.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 028b25b7f2b8ea9e7e423ec5858ba8aa6b4ffdad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->