### PR TITLE
Add Fallow CI workflow

### DIFF
--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   fallow:

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -26,3 +26,5 @@ jobs:
 
       - name: Run Fallow
         uses: fallow-rs/fallow@v2
+        with:
+          fail-on-issues: false

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -1,0 +1,27 @@
+name: Fallow
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fallow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Run Fallow
+        uses: fallow-rs/fallow@v2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a dedicated GitHub Actions workflow for Fallow codebase intelligence.
- Run the official `fallow-rs/fallow@v2` action on pull requests, pushes to `main`, and manual dispatch.
- Configure checkout with full history so Fallow can use git-based CI analysis when needed.
- Use `actions/checkout@v6`.
- Grant `security-events: write` so SARIF upload can work when GitHub Code Scanning is enabled.
- Set `fail-on-issues: false` so Fallow reports annotations/SARIF without blocking on the repo's existing findings during initial adoption.

## Testing
- Ran `npx fallow --format json --quiet --explain 2>/dev/null || true`; Fallow v2.56.0 loaded the existing repo config and completed analysis successfully.
- Investigated the failed workflow log: Fallow auto-scoped to the PR base and found one existing issue, `@total-typescript/ts-reset` listed in `devDependencies` but never imported. The action default `fail-on-issues: true` caused the failure.
- Confirmed `actions/checkout@v6` is available and uses Node 24.
- `bun install --frozen-lockfile && bunx fallow ...` could not run in this cloud image because `bun` is not installed locally; the GitHub workflow installs Bun with `oven-sh/setup-bun@v2`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12b9d25b-4883-434b-b79f-6d29827dfc3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12b9d25b-4883-434b-b79f-6d29827dfc3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

