### PR TITLE
Add CI checks and dry-run deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run check
+        run: bun run check
+
+  dry-run-deploy:
+    name: Dry-run deploy
+    runs-on: ubuntu-latest
+    needs: check
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run dry-run deploy
+        run: bun run deploy:dry-run

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "dev": "wrangler dev --env development src/index.ts",
     "deploy": "wrangler deploy --minify src/index.ts",
+    "deploy:dry-run": "wrangler deploy --dry-run --minify src/index.ts",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "dev": "wrangler dev --env development src/index.ts",
     "deploy": "wrangler deploy --minify src/index.ts",
-    "deploy:dry-run": "wrangler deploy --dry-run --minify src/index.ts",
+    "deploy:dry-run": "wrangler deploy --dry-run --env=\"\" --minify src/index.ts",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "typecheck": "tsc --noEmit",

--- a/test/api-contract.test.ts
+++ b/test/api-contract.test.ts
@@ -355,14 +355,20 @@ describe("v1 API contract", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("application/json");
 
-    const body = await response.json();
+    const body = readSearchResults(await jsonBody(response));
+    const mortgageTimeSeriesResult = body.find(
+      (result) =>
+        result.url === "/api-reference/endpoint/mortgage-rates/time-series",
+    );
 
-    expect(body).toContainEqual(
+    expect(mortgageTimeSeriesResult).toEqual(
       expect.objectContaining({
         type: expect.stringMatching(/^(page|heading|text)$/),
         url: "/api-reference/endpoint/mortgage-rates/time-series",
-        content: expect.stringContaining("Mortgage Rates Time Series"),
       }),
+    );
+    expect(stripSearchHighlights(mortgageTimeSeriesResult?.content)).toContain(
+      "Mortgage Rates Time Series",
     );
   });
 
@@ -721,6 +727,34 @@ function isDataType(value: string): value is DataType {
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
+}
+
+function readSearchResults(
+  value: unknown,
+): Array<{ content: string; type: string; url: string }> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((item) => {
+    if (!isRecord(item)) {
+      return [];
+    }
+
+    const content = readString(item.content);
+    const type = readString(item.type);
+    const url = readString(item.url);
+
+    if (!content || !type || !url) {
+      return [];
+    }
+
+    return [{ content, type, url }];
+  });
+}
+
+function stripSearchHighlights(value: string | undefined): string {
+  return value?.replaceAll(/<\/?mark>/g, "") ?? "";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a CI workflow for pull requests and pushes to `main`.
- Run `bun run check` as one CI job and a Wrangler dry-run deploy as a separate dependent job.
- Add a `deploy:dry-run` package script that targets the top-level Wrangler environment explicitly.
- Update the docs search contract test to tolerate the highlighted search snippets returned by Fumadocs.

## Verification
- `bun run lint`
- `bun run check`
- `bun run deploy:dry-run`
- Commit hook ran `bun test` successfully before each commit.

## Notes
- Installed Bun and project dependencies in the agent environment to reproduce `bun run check`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-942f4198-492b-4d77-8ff3-1271ce02abc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-942f4198-492b-4d77-8ff3-1271ce02abc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

